### PR TITLE
Remove Hardcoded Example Plugin

### DIFF
--- a/zeus/cli/bootstrap.py
+++ b/zeus/cli/bootstrap.py
@@ -5,8 +5,6 @@
 
 from cement.core import handler
 from zeus.cli.controllers.base import MyCLIBaseController
-from zeus.cli.plugins.example import ExamplePluginController
 
 def load(app):
     handler.register(MyCLIBaseController)
-    handler.register(ExamplePluginController)


### PR DESCRIPTION
You need to add your `plugin_config_dir` in development so that plugins are loaded:

I.e.

**~/.zeus.conf**

```
[zeus]
plugin_config_dir = /path/to/you/zeus/development/sources/config/plugins.d
```
